### PR TITLE
Fix contributing link in readme and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+setup: node_modules
+
 node_modules:
 	@npm install
 

--- a/README.md
+++ b/README.md
@@ -35,5 +35,4 @@ You mean besides incredibly good karma? Here are some very likely outcomes:
 
 ## Contributing
 
-This coach manual is maintained by [DjangoGirls](http://djangogirls.org/). If you find any mistakes or want to update the 
-tutorial please [follow the contributing guidelines](https://github.com/DjangoGirls/coach-manual/contributing/).
+This coach manual is maintained by [DjangoGirls](http://djangogirls.org/). If you find any mistakes or want to update the tutorial please [follow the contributing guidelines](/contributing/).


### PR DESCRIPTION
Fix Makefile by adding setup target

`make dev` is currently failing since it has `setup` as prerequisites
which is non existent. This commit will add an empty setup target which
requires node_modules as prerequisites similar to how its done in the
DjangoGirls main repository.

Fix contributing link in README.md

The contributing link at the bottom of the README is currently pointing
to: `https://github.com/DjangoGirls/coach-manual/contributing/` which
will result in a 404. Removing the domain part from the URL will result
in the URL correctly working using `honkit serve` as well as in GitHub
Markdown rendering.
