### PR TITLE
Remove Skype and replace with most popular communication apps

### DIFF
--- a/intro/README.md
+++ b/intro/README.md
@@ -13,8 +13,8 @@ Most of our workshops are done in English, so we expect you to speak it fluently
 
 Django Girls is designed to be a one-day workshop. However, sometimes the event could take two days, or there may be a shorter installation event the evening before. Apart from time you will spend actually coaching, there are a number of things you need to consider, which will take some of your time:
 
-* Getting to know your group - we encourage to say hi and meet with your group before the workshop. This could involve writing an e-mail to introduce yourself, and possibly a chat via hangout or Skype with all the people in your group (__~1-2 hours__).
-* Helping out with installation before the workshops - either done via Skype/Google hangout/e-mails or a day before the workshop. You will need __3+ hours__ for that.
+* Getting to know your group - we encourage to say hi and meet with your group before the workshop. This could involve writing an e-mail to introduce yourself, and possibly a chat via GoogleHangout/MSTeams/Zoom with all the people in your group (__~1-2 hours__).
+* Helping out with installation before the workshops - either done via GoogleHangout/MSTeams/Zoom/e-mails or a day before the workshop. You will need __3+ hours__ for that.
 * For some Django Girls events there may be pre- or post-workshop meetups (__~1-3h__).
 
 # Tutorial
@@ -34,7 +34,7 @@ The tutorial covers:
 
 # Pre-workshop installation
 
-There is a lot to learn in the tutorial!  Attendees will have more time to learn at the workshop if they come with everything they need already installed.  Most Django Girls events include a pre-workshop meetup in the evening or day(s) beforehand, where you can help your group with installation and check that their system is ready to go.  This could be in person or by Skype/Google hangout etc.
+There is a lot to learn in the tutorial!  Attendees will have more time to learn at the workshop if they come with everything they need already installed.  Most Django Girls events include a pre-workshop meetup in the evening or day(s) beforehand, where you can help your group with installation and check that their system is ready to go.  This could be in person or by Google hangout/Teams/Zoom etc.
 
 We recommend pointing attendees at the [Installation chapter](http://tutorial.djangogirls.org/en/installation/index.html) prior to the workshop, this takes them through some basic setup steps and some introductory material. It is of course fine to discuss the material and answer any questions they have, but we want them to be able to start coding right away!
 

--- a/intro/README.md
+++ b/intro/README.md
@@ -34,7 +34,7 @@ The tutorial covers:
 
 # Pre-workshop installation
 
-There is a lot to learn in the tutorial!  Attendees will have more time to learn at the workshop if they come with everything they need already installed.  Most Django Girls events include a pre-workshop meetup in the evening or day(s) beforehand, where you can help your group with installation and check that their system is ready to go.  This could be in person or by Google hangout/Teams/Zoom etc.
+There is a lot to learn in the tutorial!  Attendees will have more time to learn at the workshop if they come with everything they need already installed.  Most Django Girls events include a pre-workshop meetup in the evening or day(s) beforehand, where you can help your group with installation and check that their system is ready to go.  This could be in person or by GoogleHangout/Teams/Zoom etc.
 
 We recommend pointing attendees at the [Installation chapter](http://tutorial.djangogirls.org/en/installation/index.html) prior to the workshop, this takes them through some basic setup steps and some introductory material. It is of course fine to discuss the material and answer any questions they have, but we want them to be able to start coding right away!
 

--- a/tips/README.md
+++ b/tips/README.md
@@ -10,7 +10,7 @@ Coaches need to be 100% focused on their learners and always be there when neede
 
 ### Be Flexible & Accessible 
 
-For attendees who are hard of hearing or would otherwise benefit from forms of communication other than talking, be prepared to use a text-based form of communication. Give them your Google hangout or Skype name and encourage them to IM you when they need help. (And remember to bring a laptop so you can check your IMs!) 
+For attendees who are hard of hearing or would otherwise benefit from forms of communication other than talking, be prepared to use a text-based form of communication. Give them your Google hangout/Teams/Zoom name and encourage them to IM you when they need help. (And remember to bring a laptop so you can check your IMs!) 
 
 Attendees with low vision might want to increase the size of the text in their command lines, their text editors, and on web pages. They probably know how to enlarge text in their web browsers, but they might need help resizing text in other places. Don't assume anything about someone's vision; try to start the day with the statement, "And if you need help making the text size bigger or smaller when you start coding, let me know!"  
 

--- a/tips/README.md
+++ b/tips/README.md
@@ -10,7 +10,7 @@ Coaches need to be 100% focused on their learners and always be there when neede
 
 ### Be Flexible & Accessible 
 
-For attendees who are hard of hearing or would otherwise benefit from forms of communication other than talking, be prepared to use a text-based form of communication. Give them your Google hangout/Teams/Zoom name and encourage them to IM you when they need help. (And remember to bring a laptop so you can check your IMs!) 
+For attendees who are hard of hearing or would otherwise benefit from forms of communication other than talking, be prepared to use a text-based form of communication. Give them your GoogleHangout/Teams/Zoom name and encourage them to IM you when they need help. (And remember to bring a laptop so you can check your IMs!) 
 
 Attendees with low vision might want to increase the size of the text in their command lines, their text editors, and on web pages. They probably know how to enlarge text in their web browsers, but they might need help resizing text in other places. Don't assume anything about someone's vision; try to start the day with the statement, "And if you need help making the text size bigger or smaller when you start coding, let me know!"  
 


### PR DESCRIPTION
Skype was discontinued for most users, with the service being retired on May 5, 2025, and replaced by Microsoft Teams